### PR TITLE
"&gt &lt &nbsp &amp &quot" tag converted

### DIFF
--- a/hubot-scripts.json
+++ b/hubot-scripts.json
@@ -2,6 +2,5 @@
   "help",
   "tweet",
   "ascii",
-  "roles",
-  "shorten"
+  "roles"
 ]

--- a/lib/Hubot/Scripts/shorten.pm
+++ b/lib/Hubot/Scripts/shorten.pm
@@ -83,30 +83,19 @@ sub load {
                     $title = 'no title' unless $title;
                     $title =~ s/\n//g;
                     $title =~ s/(^\s+|\s+$)//g;
-                    $title = html_conv($title);
+
+                    ## unescape html
+                    $title =~ s/&amp;/&/g;
+                    $title =~ s/&lt;/</g;
+                    $title =~ s/&gt;/>/g;
+                    $title =~ s/&quot;/"/g;
+                    $title =~ s/&apos;/'/g;
 
                     $msg->send("[$title] - $bitly");
                 }
               );
         }
     );
-}
-
-sub html_conv {
-    my %tags = (
-            '&nbsp;'    => ' ',
-            '&amp;'     => '&',
-            '&gt;'      => '>',
-            '&lt;'      => '<',
-            '&quot;'    => '"',
-        );
-
-    my $before_title = shift @_;
-
-    foreach my $key (keys %tags) {
-        $before_title =~ s/($key)/$tags{$key}/g;
-    }
-    return $before_title;
 }
 
 1;


### PR DESCRIPTION
형석님 shorten.pm이 html tag중 gt lt amp nbsp quot등의 tag의 처리가 되지 않는걸 보고
(irc에서 hongbot이 뿌리는 타이틀) 저부분을 처리하게 고쳐봤습니다.

풀리퀘를 보내니 검토해주시면 감사합니다.
