### PR TITLE
add HUBOT_HTTPD_ADDRESS - to use listen address for Hubot

### DIFF
--- a/lib/Hubot/Robot.pm
+++ b/lib/Hubot/Robot.pm
@@ -59,7 +59,7 @@ sub BUILD {
 sub setupHerokuPing {
     my $self = shift;
 
-    my $httpd = AnyEvent::HTTPD->new( port => $ENV{PORT} || 8080 );
+    my $httpd = AnyEvent::HTTPD->new( port => $ENV{PORT} || 8080, host => $ENV{HUBOT_HTTPD_ADDRESS} || '0.0.0.0' );
     $httpd->reg_cb(
         '/hubot/ping' => sub {
             my ( $httpd, $req ) = @_;


### PR DESCRIPTION
you can now use env variable HUBOT_HTTPD_ADDRESS to specify the listen address of the anyevent httpd module
