### PR TITLE
fix uninitialized value of msg

### DIFF
--- a/lib/Hubot/Adapter/Irc.pm
+++ b/lib/Hubot/Adapter/Irc.pm
@@ -142,6 +142,8 @@ sub run {
         part => sub {
             my ( $cl, $nick, $channel, $is_myself, $msg ) = @_;
 
+            $msg = "no quit message" unless $msg;
+
             print "$nick leaves $channel: $msg\n";
             my $user = $self->createUser( $channel, $nick );
             $self->receive(
@@ -149,6 +151,8 @@ sub run {
         },
         quit => sub {
             my ( $cl, $nick, $msg ) = @_;
+
+            $msg = "no quit message" unless $msg;
 
             print "$nick quit: $msg\n";
             my $user = $self->createUser( '', $nick )


### PR DESCRIPTION
if a user leaves or quits without a message, the following shows up in the error log:

hggh quit:
Use of uninitialized value $msg in concatenation (.) or string at lib/Hubot/Adapter/Irc.pm line 153.

hggh leaves:
Use of uninitialized value $msg in concatenation (.) or string at lib/Hubot/Adapter/Irc.pm line 145.
